### PR TITLE
Add Flask-based Sora Invite Code Hunter application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.venv/
+__pycache__/
+*.py[cod]
+.DS_Store
+.env
+.env.*
+.eggs/
+build/
+dist/
+.idea/
+.vscode/

--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "python sora_hunt.py"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sora Invite Code Hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,325 +1,83 @@
-You want a crisp spec and a turnkey README so a code-gen model can crank out the repo without getting lost. Fine. Here’s both: an implementation outline (clear enough for an LLM to map to code) and a clean `README.md` you can paste straight into GitHub. The artifacts below are written neutrally on purpose so the robot army doesn’t hallucinate your sarcasm into function names.
-
----
-
-# Implementation Outline (Functional + Technical)
-
-## 1) Problem & Goal
-
-* **Problem:** Sora invite codes are posted in chaotic public threads and expire fast. Manual hunting wastes time.
-* **Goal:** A lightweight app that continuously scans public sources (starting with Reddit search JSON), extracts likely codes via regex, de-duplicates them, and serves a live list via a tiny web UI and JSON endpoint. Easy to deploy on Replit or locally.
-
-## 2) Core Features (MVP)
-
-1. **Polling worker**
-
-   * Periodically query Reddit’s public search JSON API for configured terms.
-   * Parse titles/selftext for short alphanumeric tokens that match code-like patterns.
-   * Heuristics to reduce false positives (must include at least one digit, length 5–8, skip all-alpha tiny tokens, maintain denylist).
-   * Maintain an in-memory set to avoid re-emitting duplicates.
-
-2. **Storage**
-
-   * In-memory list of candidate codes with timestamp and source URL.
-   * Optional: pluggable persistence layer (JSON file or SQLite) via env flag.
-
-3. **Web API + UI**
-
-   * `GET /` simple HTML table showing candidates, newest first.
-   * `GET /codes.json` returns current snapshot: last poll time, candidates array.
-   * CORS-safe, no auth required by default.
-
-4. **Configuration**
-
-   * Environment variables for poll interval, query, max posts, user agent, source toggles.
-   * Sensible defaults so it runs out of the box.
-
-5. **Ethics/Rate Limits**
-
-   * Polite polling interval, user agent string, no abusive scraping.
-
-## 3) Nice-to-Have (Post-MVP)
-
-* Multiple sources: X/Twitter (requires API or puppeteer-like headless), Discord channels (if allowed), specialized forums.
-* Persistence: enable `STORE=sqlite` with schema migration.
-* Web UI extras: copy button, “mark tried,” export CSV.
-* Webhook to Discord or Slack when new code appears.
-* Simple keyword filters or per-subreddit targeting.
-* Basic auth gate for `/` if you don’t want it public.
-
-## 4) Inputs & Outputs
-
-* **Input:** Public JSON search responses (Reddit at launch).
-* **Processing:** Regex identify `[A-Z0-9]{5,8}` tokens; filter; de-dupe; enrich with source link.
-* **Output:** HTML table at `/` and JSON feed at `/codes.json`.
-
-## 5) Data Model
-
-```ts
-type CandidateCode = {
-  code: string;            // e.g. "7ZDCNP"
-  example_text: string;    // short snippet from title/selftext
-  source_title: string;    // original post title
-  url: string;             // source post URL
-  discovered_at: string;   // ISO timestamp (UTC)
-};
-
-type Snapshot = {
-  last_poll: string;       // ISO timestamp or "error: ..."
-  candidates: CandidateCode[];
-};
-```
-
-## 6) API Surface
-
-* `GET /`
-  Renders HTML table of codes. No query params.
-* `GET /codes.json`
-  Returns `Snapshot` JSON object.
-* Health check (optional): `GET /healthz` returns `{ ok: true }`.
-
-## 7) Configuration (Env Vars)
-
-* `POLL_INTERVAL_SECONDS` default `60`
-* `MAX_POSTS` default `75`
-* `QUERY` default `Sora invite code OR "Sora 2 invite" OR "Sora2 invite"`
-* `USER_AGENT` default `sora-hunter/0.1`
-* `STORE` optional: `memory` (default) or `json` or `sqlite`
-* `STORE_PATH` when `STORE=json`, e.g. `data/codes.json`
-
-## 8) Architecture
-
-* **Process layout:** single process, one background polling thread, one Flask app thread.
-* **Concurrency:** thread-safe updates guarded by a lock.
-* **State:** memory or optional persistence file/SQLite.
-
-## 9) File/Repo Structure
-
-```
-.
-├─ README.md
-├─ sora_hunt.py               # Flask app + polling worker
-├─ requirements.txt
-├─ .replit                    # Replit run config
-├─ replit.nix                 # optional Replit nix env
-├─ .gitignore
-└─ LICENSE
-```
-
-## 10) Pseudocode
-
-```python
-global_seen = set()
-latest = { "last_poll": None, "candidates": [] }
-lock = threading.Lock()
-
-def poll_loop():
-    while True:
-        try:
-            payload = fetch_reddit_json(query=QUERY, limit=MAX_POSTS)
-            items = parse_items(payload)  # yield (title, selftext, url)
-            now = utc_now_iso()
-            new_batch = []
-            for title, selftext, url in items:
-                codes = extract_codes(title + "\n" + selftext)
-                for c in codes:
-                    if c not in global_seen:
-                        global_seen.add(c)
-                        new_batch.append({
-                            "code": c,
-                            "example_text": title[:220] or selftext[:220],
-                            "source_title": title,
-                            "url": url,
-                            "discovered_at": now
-                        })
-            with lock:
-                latest["last_poll"] = now
-                if new_batch:
-                    latest["candidates"] = new_batch + latest["candidates"]
-                persist_if_enabled(latest)
-        except Exception as e:
-            with lock:
-                latest["last_poll"] = f"error: {e}"
-        sleep(POLL_INTERVAL_SECONDS)
-
-# Flask routes read from 'latest' under lock and render HTML/JSON.
-```
-
-## 11) Validation & Testing
-
-* Unit tests for `extract_codes_from_text` with false-positive words and edge cases.
-* Smoke test: app starts, `/` and `/codes.json` return 200.
-* Rate limit check: ensure interval respected.
-* Regression: repeated polling doesn’t duplicate entries.
-
-## 12) Constraints & Risks
-
-* Public endpoints can change or throttle; keep intervals modest.
-* Many extracted tokens will be dead. This is a discovery tool, not a guarantee machine.
-* Avoid reselling codes; follow platform terms.
-
----
-
-# `README.md` (Paste into GitHub)
-
-````markdown
 # Sora Invite Code Hunter
 
-Lightweight Flask app that polls public Reddit search results for posts that might contain **Sora invite codes**, extracts likely codes with simple heuristics, and serves a live feed at a web page (`/`) and JSON endpoint (`/codes.json`).
-
-> **Note:** This discovers **candidate** codes only. Codes are ephemeral and may be invalid by the time you try them. Use responsibly. Do not buy or resell codes.
-
----
+Sora Invite Code Hunter is a lightweight Flask application that continuously scans Reddit for potential Sora invite codes and presents the latest findings in a friendly dashboard and JSON feed. A background worker polls Reddit's public search API, extracts candidate codes with a strict pattern, and keeps a deduplicated in-memory list for quick monitoring.
 
 ## Features
-- Background poller scans Reddit search JSON at a configurable interval
-- Regex extraction for short mixed alphanumeric tokens (length 5–8) with heuristic filters
-- De-duplication and timestamping
-- Minimal web UI at `/` and machine-readable JSON at `/codes.json`
-- One-file deploy; runs on Replit or locally
 
-## Quick Start (Local)
-```bash
-git clone https://github.com/<your-username>/sora-invite-hunt.git
-cd sora-invite-hunt
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-python sora_hunt.py
-# open http://127.0.0.1:3000
-````
+- 🔁 Background polling thread with configurable interval and search query
+- 🔎 Regex-based extraction of 5–8 character alpha-numeric codes that contain at least one digit
+- 🧠 In-memory deduplication with thread-safe access
+- 🌐 Clean HTML dashboard and JSON API for integrations
+- ⚙️ Runtime configuration through environment variables
 
-## Quick Start (Replit)
+## Quick Start
 
-1. Create a **Python** Repl.
-2. Add the repo files.
-3. Replit installs `requirements.txt` automatically.
-4. Press **Run** and open the public URL (port `3000`).
+### Run locally
+
+1. **Create a virtual environment** (Python 3.11+ recommended):
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Launch the app**:
+   ```bash
+   python sora_hunt.py
+   ```
+4. Visit [http://localhost:3000](http://localhost:3000) to view the dashboard.
+
+### Run on Replit
+
+1. Import this repository into Replit.
+2. Replit detects `replit.nix` and prepares the Python 3.11 environment.
+3. Click **Run** (configured in `.replit`) to start `python sora_hunt.py`.
+4. Open the hosted URL to access the dashboard.
 
 ## Configuration
 
-All config is optional and can be set via environment variables:
+Use environment variables to adjust runtime behavior without changing code:
 
-| Variable                | Default                                                 | Description                                      |
-| ----------------------- | ------------------------------------------------------- | ------------------------------------------------ |
-| `POLL_INTERVAL_SECONDS` | `60`                                                    | Seconds between polls                            |
-| `MAX_POSTS`             | `75`                                                    | Number of search results to scan                 |
-| `QUERY`                 | `Sora invite code OR "Sora 2 invite" OR "Sora2 invite"` | Search query                                     |
-| `USER_AGENT`            | `sora-hunter/0.1`                                       | HTTP user-agent string                           |
-| `STORE`                 | `memory`                                                | `memory`, `json`, or `sqlite` (optional feature) |
-| `STORE_PATH`            | `data/codes.json`                                       | Path used when `STORE=json`                      |
+| Variable | Default | Description |
+| --- | --- | --- |
+| `POLL_INTERVAL_SECONDS` | `60` | Seconds between Reddit polling cycles (minimum enforced: 10 seconds). |
+| `MAX_POSTS` | `75` | Maximum number of Reddit search results to inspect per poll (clamped to 1–100). |
+| `QUERY` | `Sora invite code OR 'Sora 2 invite' OR 'Sora2 invite'` | Reddit search query string. |
+| `USER_AGENT` | `sora-hunter/0.1` | User-Agent header sent to Reddit's API. |
+| `PORT` | `3000` | Port the Flask app listens on when run directly. |
+| `HOST` | `0.0.0.0` | Bind address when running the Flask development server. |
 
-Set via shell:
+Set variables inline when launching:
 
 ```bash
-export POLL_INTERVAL_SECONDS=90
-export MAX_POSTS=100
-export QUERY='Sora invite code'
-python sora_hunt.py
+POLL_INTERVAL_SECONDS=30 QUERY="Sora invite" python sora_hunt.py
 ```
 
-## How It Works
+## API Endpoints
 
-1. A background thread fetches Reddit search JSON with the configured query.
-2. The app extracts code-like tokens with a regex and filters obvious false positives.
-3. New candidates are de-duplicated and prepended to the in-memory list.
-4. The Flask app exposes:
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/` | Human-friendly HTML table showing the newest candidate codes first. |
+| `GET` | `/codes.json` | JSON payload containing configuration snapshot, last poll timestamp, and candidate list. |
 
-   * **`GET /`**: simple HTML table of candidates (newest first)
-   * **`GET /codes.json`**: JSON snapshot `{ last_poll, candidates[] }`
+## Candidate Data Model
 
-### Data Model
+Each candidate entry returned by `/codes.json` looks like this:
 
 ```json
 {
-  "last_poll": "2025-10-04T15:25:33Z",
-  "candidates": [
-    {
-      "code": "7ZDCNP",
-      "example_text": "Thread title or short snippet...",
-      "source_title": "Original post title",
-      "url": "https://www.reddit.com/...",
-      "discovered_at": "2025-10-04T15:25:33Z"
-    }
-  ]
+  "code": "S0RA1",
+  "example_text": "... excerpt from the Reddit post ...",
+  "source_title": "Post title containing the code",
+  "url": "https://www.reddit.com/r/example/comments/abc123/example",
+  "discovered_at": "2024-04-10T12:34:56.789123+00:00"
 }
 ```
 
-## File Structure
-
-```
-.
-├─ README.md
-├─ sora_hunt.py
-├─ requirements.txt
-├─ .replit
-├─ replit.nix
-├─ .gitignore
-└─ LICENSE
-```
-
-## Endpoints
-
-* `GET /` — HTML table with candidates
-* `GET /codes.json` — JSON snapshot
-* Optional: `GET /healthz` — returns `{ "ok": true }` (add if needed)
-
-## Limitations
-
-* Public endpoints change or throttle; keep intervals reasonable.
-* Regex is heuristic and will include some false positives by design.
-* This is for discovery only; many codes expire quickly.
-* Do not use this to buy/sell invites or violate platform terms.
-
-## Roadmap (Optional)
-
-* Additional sources (X/Twitter API, Discord channels where allowed)
-* SQLite persistence and basic search
-* Webhook notifications (Discord/Slack)
-* Mark-as-tried UI and CSV export
-* Per-subreddit or keyword filters
-
-## Development
-
-Run tests (if you add them):
-
-```bash
-pytest -q
-```
-
-Lint/format (if enabled):
-
-```bash
-ruff check .
-black .
-```
+The list is deduplicated by `code` and ordered newest-first when served.
 
 ## License
 
-MIT
-
-```
-
----
-
-# Extra: “Codex Build Notes” (for codegen prompts)
-
-Use this when you feed the outline to a code model:
-
-- Language: Python 3.11+
-- Web framework: Flask
-- Dependencies: `Flask>=3.0.0`, `requests>=2.31.0`
-- Single-file app with background thread for polling
-- Expose `GET /` and `GET /codes.json`
-- Configuration via environment variables listed above
-- Include basic HTML template string for `/`
-- Implement graceful error reporting by setting `latest["last_poll"] = "error: <msg>"`
-- Regex: `\b[A-Z0-9]{5,8}\b`, require at least one digit
-- De-duplication: global `set()` of seen codes
-- Thread-safety: `threading.Lock()` around shared state
-- Default port 3000, bind `0.0.0.0`
-- Optional persistence behind env switch is OK but not required for MVP
-
-There. Now you’ve got a blueprint and a README that won’t embarrass you in public. Go feed it to your favorite code genie and pretend it was easy.
-::contentReference[oaicite:0]{index=0}
-```
+This project is distributed under the [MIT License](LICENSE).

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,6 @@
+{ pkgs }: {
+  deps = [
+    pkgs.python311
+    pkgs.python311Packages.pip
+  ];
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=3.0.0
+requests>=2.31.0

--- a/sora_hunt.py
+++ b/sora_hunt.py
@@ -1,0 +1,230 @@
+"""Sora Invite Code Hunter web application."""
+
+from __future__ import annotations
+
+import html
+import logging
+import os
+import re
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+import requests
+from flask import Flask, jsonify, render_template_string
+
+# Configuration defaults
+DEFAULT_QUERY = "Sora invite code OR 'Sora 2 invite' OR 'Sora2 invite'"
+DEFAULT_USER_AGENT = "sora-hunter/0.1"
+DEFAULT_POLL_INTERVAL = 60
+DEFAULT_MAX_POSTS = 75
+
+REDDIT_SEARCH_URL = "https://www.reddit.com/search.json"
+TOKEN_PATTERN = re.compile(r"\b[A-Z0-9]{5,8}\b")
+
+app = Flask(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+# Shared state guarded by a lock
+_state_lock = threading.Lock()
+_candidates: List[Dict[str, str]] = []
+_seen_codes: set[str] = set()
+_last_poll: Optional[str] = None
+
+
+def _get_config() -> Dict[str, str | int]:
+    """Read configuration from environment variables."""
+    poll_interval = int(os.getenv("POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL))
+    max_posts = int(os.getenv("MAX_POSTS", DEFAULT_MAX_POSTS))
+    query = os.getenv("QUERY", DEFAULT_QUERY)
+    user_agent = os.getenv("USER_AGENT", DEFAULT_USER_AGENT)
+    return {
+        "poll_interval": max(10, poll_interval),
+        "max_posts": max(1, min(max_posts, 100)),
+        "query": query,
+        "user_agent": user_agent,
+    }
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _extract_tokens(text: str) -> List[str]:
+    """Extract candidate tokens from text using the defined pattern."""
+    uppercase_text = text.upper()
+    candidates = []
+    for token in TOKEN_PATTERN.findall(uppercase_text):
+        if any(ch.isdigit() for ch in token):
+            candidates.append(token)
+    return candidates
+
+
+def _build_example_snippet(title: str, body: str, token: str) -> str:
+    """Create a short snippet from the source text highlighting the token."""
+    combined = f"{title}\n{body}".strip()
+    if not combined:
+        return title or token
+
+    match = re.search(re.escape(token), combined, re.IGNORECASE)
+    if not match:
+        snippet = combined[:160]
+    else:
+        start = max(match.start() - 40, 0)
+        end = min(match.end() + 40, len(combined))
+        snippet = combined[start:end]
+    snippet = snippet.replace("\n", " ")
+    return html.escape(snippet.strip())
+
+
+def _poll_reddit() -> None:
+    """Continuously poll Reddit for invite codes."""
+    global _last_poll
+    while True:
+        start_time = time.time()
+        config = _get_config()
+        logging.debug("Polling Reddit with interval=%s query=\"%s\" limit=%s", config["poll_interval"], config["query"], config["max_posts"])
+        try:
+            params = {
+                "q": config["query"],
+                "sort": "new",
+                "limit": config["max_posts"],
+                "restrict_sr": False,
+            }
+            headers = {"User-Agent": config["user_agent"]}
+            response = requests.get(REDDIT_SEARCH_URL, params=params, headers=headers, timeout=20)
+            response.raise_for_status()
+            payload = response.json()
+            items = payload.get("data", {}).get("children", [])
+
+            new_candidates: List[Dict[str, str]] = []
+            for item in items:
+                data = item.get("data", {})
+                title = data.get("title", "")
+                body = data.get("selftext", "") or ""
+                permalink = data.get("permalink") or ""
+                url = f"https://www.reddit.com{permalink}" if permalink else data.get("url", "")
+                tokens = _extract_tokens(f"{title}\n{body}")
+
+                for token in tokens:
+                    with _state_lock:
+                        if token in _seen_codes:
+                            continue
+                    snippet = _build_example_snippet(title, body, token)
+                    candidate = {
+                        "code": token,
+                        "example_text": snippet,
+                        "source_title": title,
+                        "url": url,
+                        "discovered_at": _iso_now(),
+                    }
+                    with _state_lock:
+                        _seen_codes.add(token)
+                        _candidates.append(candidate)
+                    new_candidates.append(candidate)
+
+            logging.info("Poll completed: %d new candidate(s) found", len(new_candidates))
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.exception("Error while polling Reddit: %s", exc)
+        finally:
+            with _state_lock:
+                _last_poll = _iso_now()
+
+        elapsed = time.time() - start_time
+        sleep_for = max(config["poll_interval"] - elapsed, 5)
+        time.sleep(sleep_for)
+
+
+def _start_background_thread() -> None:
+    thread = threading.Thread(target=_poll_reddit, name="reddit-poller", daemon=True)
+    thread.start()
+    logging.info("Background Reddit polling thread started")
+
+
+@app.route("/")
+def index() -> str:
+    with _state_lock:
+        recent = list(reversed(_candidates))
+        last_poll = _last_poll
+    html_template = """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Sora Invite Code Hunter</title>
+        <style>
+            body { font-family: Arial, sans-serif; margin: 2rem; background-color: #f5f5f5; }
+            h1 { color: #333; }
+            table { border-collapse: collapse; width: 100%; background: #fff; }
+            th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+            th { background: #eee; }
+            tbody tr:nth-child(odd) { background: #fafafa; }
+            code { font-size: 1.2rem; font-weight: bold; }
+            .timestamp { white-space: nowrap; }
+        </style>
+    </head>
+    <body>
+        <h1>Sora Invite Code Hunter</h1>
+        <p>Tracking the latest potential invite codes shared on Reddit. Page auto-refreshes every 60 seconds.</p>
+        <p><strong>Last Poll:</strong> {{ last_poll or "not yet" }}</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>Code</th>
+                    <th>Example Text</th>
+                    <th>Source Title</th>
+                    <th>Discovered At</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% if candidates %}
+                    {% for item in candidates %}
+                        <tr>
+                            <td><a href="{{ item.url }}" target="_blank" rel="noopener"><code>{{ item.code }}</code></a></td>
+                            <td>{{ item.example_text|safe }}</td>
+                            <td>{{ item.source_title }}</td>
+                            <td class="timestamp">{{ item.discovered_at }}</td>
+                        </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr><td colspan="4">No candidates found yet. Check back soon!</td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+        <script>
+            setTimeout(function() { window.location.reload(); }, 60000);
+        </script>
+    </body>
+    </html>
+    """
+    return render_template_string(html_template, candidates=recent, last_poll=last_poll)
+
+
+@app.route("/codes.json")
+def codes_json():
+    config = _get_config()
+    with _state_lock:
+        snapshot = {
+            "query": config["query"],
+            "poll_interval_seconds": config["poll_interval"],
+            "max_posts": config["max_posts"],
+            "last_poll": _last_poll,
+            "candidates": list(reversed(_candidates)),
+        }
+    return jsonify(snapshot)
+
+
+# Start the background worker as soon as the module is imported
+_start_background_thread()
+
+
+def create_app() -> Flask:
+    """Factory compatible with WSGI servers."""
+    return app
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", 3000))
+    host = os.getenv("HOST", "0.0.0.0")
+    app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- implement Flask app with background Reddit polling to collect invite code candidates
- add configuration via environment variables, HTML dashboard, and JSON endpoint
- provide project metadata including README, requirements, Replit configuration, and MIT license

## Testing
- python -m compileall sora_hunt.py

------
https://chatgpt.com/codex/tasks/task_e_68e141335f84832d912d1eeb79d80c58