### PR TITLE
Restrict invite detection to six-character alphanumeric codes

### DIFF
--- a/sora_hunt.py
+++ b/sora_hunt.py
@@ -60,9 +60,7 @@ MASTODON_SEARCH_URL = "https://mastodon.social/api/v2/search"
 
 # Enhanced token pattern - supports various formats
 
-TOKEN_PATTERN = re.compile(
-    r"\b(?:[A-Z0-9]{5,12}|[A-Z0-9]{4,6}(?:-[A-Z0-9]{4,6}){1,3})\b"
-)
+TOKEN_PATTERN = re.compile(r"\b[A-Z0-9]{6}\b")
 
 INVITE_KEYWORDS = [
     "invite",
@@ -484,7 +482,11 @@ def _extract_tokens(text: str) -> List[str]:
     tokens: List[str] = []
 
     for token in TOKEN_PATTERN.findall(uppercase_text):
-        if any(ch.isdigit() for ch in token) and not any(ex in token for ex in HARD_EXCLUDE):
+        if (
+            any(ch.isdigit() for ch in token)
+            and any(ch.isalpha() for ch in token)
+            and not any(ex in token for ex in HARD_EXCLUDE)
+        ):
             tokens.append(token.strip("-"))
 
     seen: set[str] = set()


### PR DESCRIPTION
## Summary
- update invite token pattern to only match six-character alphanumeric strings
- require extracted tokens to contain both letters and digits to qualify as candidates

## Testing
- python -m compileall sora_hunt.py

------
https://chatgpt.com/codex/tasks/task_e_68e1662420dc832d9754e76ab7265afe